### PR TITLE
Add docker tagv

### DIFF
--- a/.github/workflows/publish-community-dashboard.yml
+++ b/.github/workflows/publish-community-dashboard.yml
@@ -3,6 +3,8 @@ name: Build-Push community dashboard
 on:
   push:
     branches: [ add-docker-tagv ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/publish-community-dashboard.yml
+++ b/.github/workflows/publish-community-dashboard.yml
@@ -24,7 +24,7 @@ jobs:
         images: |
           docker.io/kotalco/community-dashboard
         tags: |
-          type=semver,pattern={{raw}}
+          type=ref,event=tag
           type=sha
         flavor: |
           latest=true

--- a/.github/workflows/publish-community-dashboard.yml
+++ b/.github/workflows/publish-community-dashboard.yml
@@ -1,8 +1,8 @@
-name: Build-Push kotal dashboard
+name: Build-Push community dashboard
 
 on:
   push:
-    branches: [ main ]
+    branches: [ add-docker-tagv ]
   pull_request:
     branches: [ main ]
 
@@ -14,17 +14,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set Env
-      run: |
-        echo "BUILD_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-        echo "RELEASE_TAG=$(curl -s GET https://api.github.com/repos/kotalco/kotal/releases | jq -r '.[].name' | head -n1)" >> $GITHUB_ENV
+
+    - name: Generate Docker metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          docker.io/kotalco/community-dashboard
+        tags: |
+          type=semver,pattern={{raw}}
+          type=sha
+        flavor: |
+          latest=true
+
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    
+
     - name: Login to DockerHub
       uses: docker/login-action@v2
       with:
@@ -37,4 +46,5 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: kotalco/community-dashboard:latest,kotalco/community-dashboard:${{ env.BUILD_SHA }},kotalco/community-dashboard:${{ env.RELEASE_TAG }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-community-dashboard.yml
+++ b/.github/workflows/publish-community-dashboard.yml
@@ -25,7 +25,7 @@ jobs:
           docker.io/kotalco/community-dashboard
         tags: |
           type=ref,event=tag
-          type=sha
+          type=sha,prefix=,suffix=,format=short
         flavor: |
           latest=true
 

--- a/.github/workflows/publish-community-dashboard.yml
+++ b/.github/workflows/publish-community-dashboard.yml
@@ -2,7 +2,7 @@ name: Build-Push community dashboard
 
 on:
   push:
-    branches: [ add-docker-tagv ]
+    branches: [ main ]
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
update docker image with release tagging
================================
The workflow should be like:
1- on any PUSH or PR on main it will push 2 images
ex.
docker.io/kotalco/community-dashboard:sha-c2d8c80
docker.io/kotalco/community-dashboard:latest

2- on adding/pushing a new repo TAG
ex > 
$ git tag  v0.1-alpha.6 HEAD
$ git push origin v0.1-alpha.6
it should push
docker.io/kotalco/community-dashboard:v0.1-alpha.6
docker.io/kotalco/community-dashboard:sha-c2d8c80
docker.io/kotalco/community-dashboard:latest